### PR TITLE
Add configurable file paths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -204,3 +204,8 @@ INSTAGRAM_REDIRECT_URI=https://YOURWEBURLHERE.COM/social/handle/instagram
 # enable/disable HTTP Method column in admin's route details list
 # default value = 1
 # SHOW_ROUTE_HTTP_METHOD=0
+
+# Paths for uploaded documents and payments
+DOCS_PATH=files_documentos
+PAGOS_PATH=files_pagos
+

--- a/app/Http/Controllers/ReservaController.php
+++ b/app/Http/Controllers/ReservaController.php
@@ -61,7 +61,7 @@ class ReservaController extends Controller
 
         // Manejo del archivo
         if ($imagen = $request->file('file')) {
-            $rutaGuardarmg = 'files_documentos';
+            $rutaGuardarmg = config('files.docs_path');
             $nombreOriginal = time() . '_' . $imagen->getClientOriginalName();
             $extension = $imagen->getClientOriginalExtension();
 
@@ -260,7 +260,7 @@ class ReservaController extends Controller
     private function procesarComprobantePago(Request $request, $reservaId)
     {
         if ($imagen = $request->file('file')) {
-            $rutaGuardarmg = 'files_pagos';
+            $rutaGuardarmg = config('files.pagos_path');
             $nombreOriginal = $imagen->getClientOriginalName();
             $extension = $imagen->getClientOriginalExtension();
             $fotoPago = $nombreOriginal;

--- a/app/Http/Controllers/Venta/RescliController.php
+++ b/app/Http/Controllers/Venta/RescliController.php
@@ -63,7 +63,7 @@ class RescliController extends Controller
             $services = json_decode($request->input('servicios_seleccionados'), true);
 
             if ($imagen = $request->File('file')) {
-                $rutaGuardarmg = 'files_documentos';
+                $rutaGuardarmg = config('files.docs_path');
                 $nombreOriginal = $imagen->getClientOriginalName();
                 $extension = $imagen->getClientOriginalExtension();
 
@@ -221,7 +221,7 @@ class RescliController extends Controller
 
             // Procesar imagen si se sube una nueva
             if ($imagen = $request->file('file')) {
-                $rutaGuardarmg = 'files_documentos';
+                $rutaGuardarmg = config('files.docs_path');
                 $nombreOriginal = time() . '_' . $imagen->getClientOriginalName();
                 $extension = $imagen->getClientOriginalExtension();
 

--- a/app/Http/Controllers/Venta/ReservaController.php
+++ b/app/Http/Controllers/Venta/ReservaController.php
@@ -117,7 +117,7 @@ class ReservaController extends Controller
 
         // Manejo de archivo
         if ($imagen = $request->file('file')) {
-            $rutaGuardarmg = 'files_documentos';
+            $rutaGuardarmg = config('files.docs_path');
             $nombreOriginal = time() . '_' . $imagen->getClientOriginalName();
             $extension = $imagen->getClientOriginalExtension();
 

--- a/config/files.php
+++ b/config/files.php
@@ -1,0 +1,5 @@
+<?php
+return [
+    'docs_path' => env('DOCS_PATH', 'files_documentos'),
+    'pagos_path' => env('PAGOS_PATH', 'files_pagos'),
+];

--- a/resources/views/ventas/resclis/edit.blade.php
+++ b/resources/views/ventas/resclis/edit.blade.php
@@ -423,7 +423,7 @@
                                             <div id="preview-container">
                                                 @if(!empty($rescli->file))
                                                     @php
-                                                        $filePath = asset("public/files_documentos/$rescli->file");
+                                                        $filePath = asset(config('files.docs_path') . '/' . $rescli->file);
                                                         $extension = pathinfo($rescli->file, PATHINFO_EXTENSION);
                                                         $fileName = pathinfo($rescli->file, PATHINFO_BASENAME);
                                                     @endphp

--- a/resources/views/ventas/resclis/show.blade.php
+++ b/resources/views/ventas/resclis/show.blade.php
@@ -276,7 +276,7 @@
                                 @endphp
 
                                 @if(in_array(strtolower($fileExtension), ['jpg', 'jpeg', 'png', 'gif']))
-                                    <img src="{{ asset('public/files_documentos/' . $rescli->file) }}" class="img-fluid img-thumbnail"
+                                    <img src="{{ asset(config('files.docs_path') . '/' . $rescli->file) }}" class="img-fluid img-thumbnail"
                                         alt="Pasaporte" data-bs-toggle="modal" data-bs-target="#modalPasaporte">
                                 @elseif($fileExtension === 'pdf')
                                     <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#modalPasaporte">
@@ -300,9 +300,9 @@
                             </div>
                             <div class="modal-body text-center">
                                 @if(in_array(strtolower($fileExtension), ['jpg', 'jpeg', 'png', 'gif']))
-                                    <img src="{{ asset('public/files_documentos/' . $rescli->file) }}" class="img-fluid" alt="Pasaporte">
+                                    <img src="{{ asset(config('files.docs_path') . '/' . $rescli->file) }}" class="img-fluid" alt="Pasaporte">
                                 @elseif($fileExtension === 'pdf')
-                                    <iframe src="{{ asset('public/files_documentos/' . $rescli->file) }}" width="100%" height="500px"></iframe>
+                                    <iframe src="{{ asset(config('files.docs_path') . '/' . $rescli->file) }}" width="100%" height="500px"></iframe>
                                 @endif
                             </div>
                         </div>
@@ -326,7 +326,7 @@
                                 @endphp
 
                                 @if(in_array(strtolower($pagoExtension), ['jpg', 'jpeg', 'png', 'gif']))
-                                    <img src="{{ asset('public/files_pagos/' . $reserva->pago) }}" class="img-fluid img-thumbnail"
+                                    <img src="{{ asset(config('files.pagos_path') . '/' . $reserva->pago) }}" class="img-fluid img-thumbnail"
                                         alt="Comprobante de pago" data-bs-toggle="modal" data-bs-target="#modalComprobante">
                                 @elseif($pagoExtension === 'pdf')
                                     <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#modalComprobante">
@@ -350,9 +350,9 @@
                             </div>
                             <div class="modal-body text-center">
                                 @if(in_array(strtolower($pagoExtension), ['jpg', 'jpeg', 'png', 'gif']))
-                                    <img src="{{ asset('public/files_pagos/' . $reserva->pago) }}" class="img-fluid" alt="Comprobante de pago">
+                                    <img src="{{ asset(config('files.pagos_path') . '/' . $reserva->pago) }}" class="img-fluid" alt="Comprobante de pago">
                                 @elseif($pagoExtension === 'pdf')
-                                    <iframe src="{{ asset('public/files_pagos/' . $reserva->pago) }}" width="100%" height="500px"></iframe>
+                                    <iframe src="{{ asset(config('files.pagos_path') . '/' . $reserva->pago) }}" width="100%" height="500px"></iframe>
                                 @endif
                             </div>
                         </div>

--- a/resources/views/ventas/solicitudes/edit.blade.php
+++ b/resources/views/ventas/solicitudes/edit.blade.php
@@ -191,7 +191,7 @@
                                 @endphp
 
                                 @if(in_array(strtolower($fileExtension), ['jpg', 'jpeg', 'png', 'gif']))
-                                    <img src="{{ url('public/files_documentos/' . $reserva->turistas->first()->file) }}" 
+                                    <img src="{{ asset(config('files.docs_path') . '/' . $reserva->turistas->first()->file) }}"
                                         class="img-fluid img-thumbnail"
                                         alt="Pasaporte" data-bs-toggle="modal" data-bs-target="#modalPasaporte">
                                 @elseif($fileExtension === 'pdf')
@@ -216,10 +216,10 @@
                             </div>
                             <div class="modal-body text-center">
                                 @if(in_array(strtolower($fileExtension), ['jpg', 'jpeg', 'png', 'gif']))
-                                    <img src="{{ url('public/files_documentos/' . $reserva->turistas->first()->file) }}" 
+                                    <img src="{{ asset(config('files.docs_path') . '/' . $reserva->turistas->first()->file) }}"
                                         class="img-fluid" alt="Pasaporte">
                                 @elseif($fileExtension === 'pdf')
-                                    <iframe src="{{ url('public/files_documentos/' . $reserva->turistas->first()->file) }}" 
+                                    <iframe src="{{ asset(config('files.docs_path') . '/' . $reserva->turistas->first()->file) }}"
                                             width="100%" height="500px"></iframe>
                                 @endif
                             </div>
@@ -244,7 +244,7 @@
                                 @endphp
 
                                 @if(in_array(strtolower($pagoExtension), ['jpg', 'jpeg', 'png', 'gif']))
-                                    <img src="{{ asset('public/files_pagos/' . $reserva->pago) }}" 
+                                    <img src="{{ asset(config('files.pagos_path') . '/' . $reserva->pago) }}" 
                                         class="img-fluid img-thumbnail"
                                         alt="Comprobante de pago" data-bs-toggle="modal" data-bs-target="#modalComprobante">
                                 @elseif($pagoExtension === 'pdf')
@@ -270,10 +270,10 @@
                                 </div>
                                 <div class="modal-body text-center">
                                     @if(in_array(strtolower($pagoExtension), ['jpg', 'jpeg', 'png', 'gif']))
-                                        <img src="{{ asset('public/files_pagos/' . $reserva->pago) }}" 
+                                        <img src="{{ asset(config('files.pagos_path') . '/' . $reserva->pago) }}" 
                                             class="img-fluid" alt="Comprobante de pago">
                                     @elseif($pagoExtension === 'pdf')
-                                        <iframe src="{{ asset('public/files_pagos/' . $reserva->pago) }}" 
+                                        <iframe src="{{ asset(config('files.pagos_path') . '/' . $reserva->pago) }}" 
                                                 width="100%" height="500px"></iframe>
                                     @endif
                                 </div>
@@ -312,7 +312,7 @@
                                 
                                 @if($reserva->turistas->first()->pago)
                                     <div class="pago_cont col-md-12">
-                                        <img src="{{ asset('files_pagos') }}/{{ $reserva->turistas->first()->pago }}" class="img-fluid" alt="...">
+                                        <img src="{{ asset(config('files.pagos_path') . '/' . $reserva->turistas->first()->pago) }}" class="img-fluid" alt="...">
                                     </div>
                                 @endif
 


### PR DESCRIPTION
## Summary
- add new `config/files.php` with docs and payment locations
- read new config values in controllers when storing or retrieving files
- use config-based paths in blade templates
- add corresponding `.env` example settings

## Testing
- `npm test` *(fails: Missing script and network access)*

------
https://chatgpt.com/codex/tasks/task_e_68653a1c13c4833286fd59a97fb4c4b2