### PR TITLE
Add miembros table and model

### DIFF
--- a/app/Models/Miembro.php
+++ b/app/Models/Miembro.php
@@ -8,4 +8,15 @@ use Illuminate\Database\Eloquent\Model;
 class Miembro extends Model
 {
     use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'licencia',
+        'numero',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/database/migrations/2025_10_06_000005_create_miembros_table.php
+++ b/database/migrations/2025_10_06_000005_create_miembros_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('miembros', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->string('licencia')->nullable();
+            $table->string('numero')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('miembros');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -22,6 +22,7 @@ class DatabaseSeeder extends Seeder
         $this->call(ConnectRelationshipsSeeder::class);
         $this->call(ThemesTableSeeder::class);
         $this->call(UsersTableSeeder::class);
+        $this->call(MiembroSeeder::class);
 
         Model::reguard();
     }

--- a/database/seeders/MiembroSeeder.php
+++ b/database/seeders/MiembroSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Miembro;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class MiembroSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $user = User::first();
+
+        if ($user) {
+            Miembro::create([
+                'user_id' => $user->id,
+                'licencia' => 'ABC123',
+                'numero' => '001',
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create migration for `miembros` table with `licencia` and `numero`
- allow mass-assignment and define relationship in `Miembro` model
- seed miembros via new `MiembroSeeder`
- invoke seeder in `DatabaseSeeder`

## Testing
- `php artisan --version` *(fails: php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68654b0d41a48332a933d13a76c16dfd